### PR TITLE
2-fnzksxl

### DIFF
--- a/fnzksxl/README.md
+++ b/fnzksxl/README.md
@@ -3,5 +3,5 @@
 | 차시 |    날짜    | 문제유형 | 링크 | 풀이 |
 |:----:|:---------:|:----:|:-----:|:----:|
 | 1차시 | 2024-01-15 |  다익스트라  | [부대 복귀](https://school.programmers.co.kr/learn/courses/30/lessons/132266)  | [#2](https://github.com/AlgoLeadMe/AlgoLeadMe-6/pull/2) |
-| 2차시 | 2024-01-18 | 위상 정렬 | [문제집](https://www.acmicpc.net/problem/1766) | - |
+| 2차시 | 2024-01-18 | 위상 정렬 | [문제집](https://www.acmicpc.net/problem/1766) | [#6](https://github.com/AlgoLeadMe/AlgoLeadMe-6/pull/6) |
 ---

--- a/fnzksxl/README.md
+++ b/fnzksxl/README.md
@@ -3,4 +3,5 @@
 | 차시 |    날짜    | 문제유형 | 링크 | 풀이 |
 |:----:|:---------:|:----:|:-----:|:----:|
 | 1차시 | 2024-01-15 |  다익스트라  | [부대 복귀](https://school.programmers.co.kr/learn/courses/30/lessons/132266)  | [#2](https://github.com/AlgoLeadMe/AlgoLeadMe-6/pull/2) |
+| 2차시 | 2024-01-18 | 위상 정렬 | [문제집](https://www.acmicpc.net/problem/1766) | - |
 ---

--- a/fnzksxl/위상 정렬/문제집.py
+++ b/fnzksxl/위상 정렬/문제집.py
@@ -1,0 +1,28 @@
+import sys
+import heapq
+
+input = sys.stdin.readline
+
+N, m = map(int, input().split())
+degree = [0] * (N+1)
+graph = [[] for _ in range(N+1)]
+heap = []
+
+for _ in range(m):
+    first, later = map(int, input().split())
+    degree[later] += 1
+    graph[first].append(later)
+
+for i in range(1, N+1):
+    if not degree[i]:
+        heapq.heappush(heap, i)
+
+        
+while heap:
+    cur = heapq.heappop(heap)
+    print(cur, end=" ")
+    
+    for node in graph[cur]:
+        degree[node] -= 1
+        if not degree[node]:
+            heapq.heappush(heap, node)


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[문제집](https://www.acmicpc.net/problem/1766)

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
1시간

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->

** 문제 조건 **
> N개의 문제는 모두 풀어야 한다.
먼저 푸는 것이 좋은 문제가 있는 문제는, 먼저 푸는 것이 좋은 문제를 반드시 먼저 풀어야 한다.
-> 순서가 있다.
가능하면 쉬운 문제부터 풀어야 한다.
-> 음?

두 번째 조건을 읽었을 때 위상 정렬로 시도해보는 것이 좋겠다고 먼저 판단했다.
(**위상 정렬**은 작업에 순서가 정해져있을 때 그 차례를 구하기 위해 사용되는 알고리즘이다.)

위상 정렬 알고리즘은 그래프를 만들고 진입 간선이 0인 노드부터 가져오는 방식으로 간단하게 구현이 가능하다.

그런데 이 문제에는 가능하면 쉬운 문제(숫자가 더 작은 노드)부터 풀어야 한다는 조건이 추가 되어 있었다.
이를 구현하기 위해서는 진입간선이 0이 아닌 노드에서 진입간선을 제거한 뒤 다시 검사할 때,
숫자가 작은 순서대로 실행해야 한다는 뜻이다.

> **테스트 케이스 입력**
6 3
1 2
2 4
3 2


처음에는 일반 큐로 popleft 메소드를 사용해서 구현했다.

1. **시작**
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-6/assets/71972587/01a1a0ed-5b70-4efd-a040-7bbba488da4b)

2. **진입 간선 0인 노드 큐에 추가**
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-6/assets/71972587/c0eaf241-6bdf-48a0-b87a-08101dbe340d)

여기서 큐에서 추가된 노드들을 popleft로 꺼내 출력하고, 뒤의 노드가 있으면 진입간선을 -1 해준다.

3. **다시 진입 간선 0인 노드 큐에 추가**
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-6/assets/71972587/bdb5a33a-1ebe-4660-a2c7-28eb0c291337)

1 3 5 6 보다 늦게 추가 된 2는 반드시 6보다 늦게 큐에서 꺼내지게 된다. (FILO)
...

같은 방식으로 진행하다 프로그램은 종료된다.

**일반 큐를 사용한 첫 번째 코드**
```python
import sys
from collections import deque

input = sys.stdin.readline

N, m = map(int, input().split())
degree = [0] * (N+1)
graph = [[] for _ in range(N+1)]
q = deque()

for _ in range(m):
    first, later = map(int, input().split())
    degree[later] += 1
    graph[first].append(later)

for i in range(1, N+1):
    if not degree[i]:
        q.append(i)

        
while heap:
    cur = q.popleft()
    print(cur, end=" ")
    
    for node in graph[cur]:
        degree[node] -= 1
        if not degree[node]:
            q.append(node)
```

최종 출력
**1 3 5 6 2 4**

최초 큐에 삽입했던 진입간선이 0이면서 난이도가 높은 문제(큰 숫자)가 먼저 출력되어서 3번 조건을 만족하지 못 했다.

그 다음 방법으로는 heap을 사용해 우선순위 큐로 다음 노드를 선택했다.

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-6/assets/71972587/f3763dc9-7bb4-4239-ba6f-c51010496e6b)

이 상황이 되었을 때를 자세히 살펴보면 위 상황과 같지만 우선순위 큐를 사용했을 때 다음에 꺼내올 노드는
2가 된다.

이렇게 하면 최초 큐에 삽입했던 진입간선이 0이면서 난이도가 높은 문제가 큐 안에 들어있더라도,
항상 큐에서 가장 낮은 숫자를 먼저 선택하게 되어, 3번 조건도 만족하면서 출력이 가능하다.

최종 출력
**1 3 2 4 5 6**

**전체 코드**
```python
import sys
import heapq

input = sys.stdin.readline

N, m = map(int, input().split())
degree = [0] * (N+1)
graph = [[] for _ in range(N+1)]
heap = []

for _ in range(m):
    first, later = map(int, input().split())
    degree[later] += 1
    graph[first].append(later)


# 진입간선이 0인 노드를 먼저 추가하는 로직이다.
# 근데 어차피 1부터 순회를 시작하기 때문에
# 굳이 heappush가 아니라 append만으로 추가해도
# 로직에는 큰 문제가 없음.
for i in range(1, N+1):
    if not degree[i]:
        heapq.heappush(heap, i)

        
while heap:
    cur = heapq.heappop(heap)
    print(cur, end=" ")
    
    for node in graph[cur]:
        degree[node] -= 1
        if not degree[node]:
            heapq.heappush(heap, node)
```

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
새롭게 알게된 내용은 아니지만 느낀점이 있다면,

민석님께서 지난번에 heappush heappop을 따로 임포트해서 사용하는 걸로 말씀을 주셨었는데,
막상 heapq만 임포트하던게 습관돼서 그런가 본능적으로 이렇게 사용하게 되네요. 습관이 참 무섭습니다.

다른 태스크에서 코드를 짤 때도 별 생각없이 관성적으로 적는게 아닌가?하고 자신을 의심하게 됐네요.
주의해야겠어요..