### PR TITLE
4-fnzksxl

### DIFF
--- a/fnzksxl/README.md
+++ b/fnzksxl/README.md
@@ -5,4 +5,5 @@
 | 1차시 | 2024-01-15 |  다익스트라  | [부대 복귀](https://school.programmers.co.kr/learn/courses/30/lessons/132266)  | [#2](https://github.com/AlgoLeadMe/AlgoLeadMe-6/pull/2) |
 | 2차시 | 2024-01-18 | 위상 정렬 | [문제집](https://www.acmicpc.net/problem/1766) | [#6](https://github.com/AlgoLeadMe/AlgoLeadMe-6/pull/6) |
 | 3차시 | 2024-01-24 | 그리디 | [소트](https://www.acmicpc.net/problem/1083) | [#15](https://github.com/AlgoLeadMe/AlgoLeadMe-6/pull/15) |
+| 4차시 | 2024-01-31 | 그리디 | [요격 시스템](https://school.programmers.co.kr/learn/courses/30/lessons/181188) | [#19] |
 ---

--- a/fnzksxl/README.md
+++ b/fnzksxl/README.md
@@ -5,5 +5,5 @@
 | 1차시 | 2024-01-15 |  다익스트라  | [부대 복귀](https://school.programmers.co.kr/learn/courses/30/lessons/132266)  | [#2](https://github.com/AlgoLeadMe/AlgoLeadMe-6/pull/2) |
 | 2차시 | 2024-01-18 | 위상 정렬 | [문제집](https://www.acmicpc.net/problem/1766) | [#6](https://github.com/AlgoLeadMe/AlgoLeadMe-6/pull/6) |
 | 3차시 | 2024-01-24 | 그리디 | [소트](https://www.acmicpc.net/problem/1083) | [#15](https://github.com/AlgoLeadMe/AlgoLeadMe-6/pull/15) |
-| 4차시 | 2024-01-31 | 그리디 | [요격 시스템](https://school.programmers.co.kr/learn/courses/30/lessons/181188) | [#19] |
+| 4차시 | 2024-01-31 | 그리디 | [요격 시스템](https://school.programmers.co.kr/learn/courses/30/lessons/181188) | [#19](https://github.com/AlgoLeadMe/AlgoLeadMe-6/pull/19) |
 ---

--- a/fnzksxl/그리디/요격시스템.py
+++ b/fnzksxl/그리디/요격시스템.py
@@ -1,0 +1,13 @@
+def solution(targets):
+    answer = 0
+    ceil = 0
+    
+    sorted_targets = sorted(targets, key=lambda x: x[1])
+    
+    for s, e in sorted_targets:
+        if s >= ceil:
+            answer += 1
+            ceil = e
+    
+    return answer
+  


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[요격 시스템](https://school.programmers.co.kr/learn/courses/30/lessons/181188)
## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
30분

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->

처음에 문제를 읽을 때 이해가 잘 안 갈 수도 있는데, 예제 사진을 보면 이해가 잘 됩니다!
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-6/assets/71972587/a75ae0d3-5e41-4157-b946-93e978d9b8b1)

> 단, 개구간 (s, e)로 표현되는 폭격 미사일은 s와 e에서 발사하는 요격 미사일로는 요격할 수 없습니다. 요격 미사일은 실수인 x 좌표에서도 발사할 수 있습니다.
--> (4,5) (3,5) (1,6) 구간들을 하나의 미사일로 처리할 수 있음.

예제 사진을 보기 전까지는 문제 자체가 긴가민가했었는데요.
사진을 보자마자 처음 든 생각이 (s,e) 개구간들이 있을 때
s가 어떠한 수보다 작으면 그 미사일들은 하나의 미사일로 요격할 수 있지 않나? 였습니다.

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-6/assets/71972587/b20ee25e-f1f4-456c-b38d-b6af49958a91)


이러한 그림을 생각해봤을 때 s들이 3보다 작으면 미사일 하나로 다 처리가 가능합니다!

### 왜 정렬하는 로직이 필요한가요?
제가 처음 생각한 로직은 천장 값을 0으로 초기화해두고 개구간이 들어올 때마다 s가 천장 이상이라면
천장 값을 이 개구간의 e로 바꾸고 미사일 개수를 올려주는 방식입니다.
여기서 미사일의 개수를 올릴 때마다 천장 값을 바꿔 고정시켜주므로
추후에 e값이 더 작은 개구간이 들어올 경우 문제가 발생합니다.

아래와 같이 (4,8) 개구간이 먼저 입력으로 들어와 천장을 8로 갱신해두었다고 가정합시다.
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-6/assets/71972587/ffeb506b-784d-4733-b8f8-f8d5aeb97799)

하지만 그 다음에 (1,3) 개구간이 입력으로 들어온다면 요격하는데에 두 개의 미사일이 필요하지만,
천장을 8로 고정시켜놓고 s인 1이 천장인 8보다 낮기 때문에 미사일의 개수를 올리지 않게 됩니다.
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-6/assets/71972587/139140fd-5fc2-4c1b-a790-795da3f2aa07)

**따라서 e를 기준 삼아 오름차순으로 정렬한 뒤에 순차적으로 검색해나가야만 문제가 발생하지 않습니다.**
위 예시의 경우 정렬 후 반드시 (1,3) (4,8)의 순서로 들어오기 때문에 천장을 갱신해나가도 괜찮겠죠?

**전체코드**
```python
def solution(targets):
    answer = 0
    ceil = 0
    
    sorted_targets = sorted(targets, key = lambda x: x[1])
    
    for s, e in sorted_targets:
        if s >= ceil:
            answer += 1
            ceil = e
    
    return answer
```


## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
